### PR TITLE
fix sign length

### DIFF
--- a/lib/signer.rb
+++ b/lib/signer.rb
@@ -113,7 +113,7 @@ class Signer
 
     signature = data_bignum.mod_exp(@key[:e], @key[:n])
 
-    signature.to_s(2).rjust(@key[:n].num_bytes % @key[:n].num_bytes % 2, 0.chr).unpack('n*').reverse.map { |w| sprintf '%04x', w }.join
+    signature.to_s(2).rjust(@key[:n].num_bytes + @key[:n].num_bytes % 2, 0.chr).unpack('n*').reverse.map { |w| sprintf '%04x', w }.join
   end
 
   protected

--- a/lib/signer.rb
+++ b/lib/signer.rb
@@ -113,7 +113,7 @@ class Signer
 
     signature = data_bignum.mod_exp(@key[:e], @key[:n])
 
-    signature.to_s(2).rjust(@key[:n].num_bytes, 0.chr).unpack('n*').reverse.map { |w| sprintf '%04x', w }.join
+    signature.to_s(2).rjust(@key[:n].num_bytes % @key[:n].num_bytes % 2, 0.chr).unpack('n*').reverse.map { |w| sprintf '%04x', w }.join
   end
 
   protected


### PR DESCRIPTION
in some cases signer create sign with length = 128 but sign must be 132,
it`s happens due to the loss of one zero byte , if the length module(@key[:n])   is odd.
it`s feature for some kwm files, one of 10000.this pull request fix this case.